### PR TITLE
More mobile platforms

### DIFF
--- a/source/derelict/util/system.d
+++ b/source/derelict/util/system.d
@@ -42,6 +42,12 @@ else enum Derelict_OS_Posix = false;
 version( Android ) enum Derelict_OS_Android = true;
 else enum Derelict_OS_Android = false;
 
+/*version( iOS ) enum Derelict_OS_iOS = true;
+else*/ enum Derelict_OS_iOS = false;
+
+/*version( WindowsRT ) enum Derelict_OS_WindowsRT = true;
+else*/ enum Derelict_OS_WindowsRT = false;
+
 version( FreeBSD ) {
 	enum Derelict_OS_AnyBSD = true;
 	enum Derelict_OS_FreeBSD = true;


### PR DESCRIPTION
Currently, there is no standard version identifier for these, but at
least make Derelict symbols for them available.
