### PR TITLE
fix c-style array decls

### DIFF
--- a/source/derelict/util/wintypes.d
+++ b/source/derelict/util/wintypes.d
@@ -195,7 +195,7 @@ version( Windows ) {
 
     struct BITMAPINFO {
         BITMAPINFOHEADER    bmiHeader;
-        RGBQUAD             bmiColors[1];
+        RGBQUAD[1]          bmiColors;
     }
 
     struct RECT {


### PR DESCRIPTION
it's now a warning in dmd HEAD, so this keeps things compiling cleanly. There are loads more of these scattered around derelict.
